### PR TITLE
Feat/improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM java:8
 
-ADD build/libs/connect-mock-0.5.5-all.jar /
+ADD build/libs/connect-mock-0.6.0-all.jar /
 
-CMD "java" "-jar" "connect-mock-0.5.5-all.jar"
+CMD "java" "-jar" "connect-mock-0.6.0-all.jar"

--- a/README.md
+++ b/README.md
@@ -26,3 +26,24 @@ helm install -n fran-test mock-connect ./helm
 ```
 
 Friendly reminder, if you want to deploy using Helm you'll need to push the docker image to a docker registry accessible from the Kubernetes cluster you want to deploy the mock-connect app into.
+
+
+### Example
+
+To create a new connector, you can use the following command:
+
+```
+curl -X POST -H "Content-Type: application/json" -d '{"name":"s3sink","config":{"connector.class":"io.lenses.connect.aws.s3.S3SinkConnector","tasks.max":"1","topics":"your-topic","s3.bucket.name":"your-bucket-name","s3.region":"your-s3-region","format.class":"io.lenses.connect.aws.s3.format.parquet.ParquetFormat","flush.size":"1000","name":"s3-sink"}}' http://localhost:18083/connectors | jq
+```
+
+To set the status of a connector, you can use the following command:
+
+```
+curl -X PUT -H "Content-Type: application/json" -d '[{"id":0,"state":"RUNNING","worker_id":"worker1","trace":"trace"},{"id":1,"state":"FAILED","worker_id":"worker1","trace":"trace"}]' http://localhost:18083/connectors/s3sink/status | jq
+```
+
+To get the status of a connector, you can use the following command:
+
+```
+curl -X GET http://localhost:18083/connectors/s3sink/status  | jq
+```

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ In addition, it currently exposes 3 different ports that emulates a Connect clus
 
 ## The Goal
 The first goal os this project is to be able to test applications that needs to interact with Kafka Connect. Having this mocked service will allow those apps to test scenarios handling several docens of connectors.
-After this first iteration, the idea is start adding some random failures on the artifitially deployed connectors and workers, so we can emulate disaster scenarios for apps speaking to Connect.
+After this first iteration, the idea is start adding some random failures on the artificially deployed connectors and workers, so we can emulate disaster scenarios for apps speaking to Connect.
 
 ## Usage
 
@@ -14,7 +14,7 @@ After this first iteration, the idea is start adding some random failures on the
 There is also a Dockerfile that will allow you to build and run the application
 
 ```
-docker build -t fperezp/mock-connect:0.5.0 .
+docker build -t fperezp/mock-connect:0.6.0 .
 ```
 
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ application {
 }
 
 group = "io.fperezp"
-version = "0.5.5"
+version = "0.6.0"
 
 val arrowVersion = "0.11.0"
 val hopliteVersion = "1.3.8"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ version = "0.5.5"
 
 val arrowVersion = "0.11.0"
 val hopliteVersion = "1.3.8"
-val ktorVersion = "1.4.1"
+val ktorVersion = "1.6.0"
 
 repositories {
     mavenCentral()

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -8,7 +8,7 @@ image:
   repository: fperezp/connect-mock
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "0.5.5"
+  tag: "0.6.0"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/src/main/kotlin/io/fperezp/connect/mock/server.kt
+++ b/src/main/kotlin/io/fperezp/connect/mock/server.kt
@@ -105,7 +105,6 @@ fun Application.main() {
     install(ForwardedHeaderSupport)
 
     routing {
-        //trace { application.log.trace(it.buildText()) }
 
         route("/") {
             get {
@@ -287,8 +286,7 @@ private fun Application.configureErrorInterceptor() {
 }
 
 private fun Application.configureJsonSerialization() {
-    install(ContentNegotiation) {
-        //register(ContentType.Application.Json, JacksonConverter())
+    install(ContentNegotiation) { 
         jackson {
             enable(SerializationFeature.INDENT_OUTPUT)
             disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -2,7 +2,7 @@ workerAPort: 8083
 workerAPort: ${?WORKER_A_PORT}
 
 workerBPort: 8183
-workerBPort: ${?WORKER_A_PORT}
+workerBPort: ${?WORKER_B_PORT}
 
 workerCPort: 8283
-workerCPort: ${?WORKER_A_PORT}
+workerCPort: ${?WORKER_C_PORT}


### PR DESCRIPTION
Adds an endpoint to control the connector tasks statuses
Extends `GET /connectors` to support expand: info + status (newer Kafka connect API)